### PR TITLE
Am I Ok?

### DIFF
--- a/include/BMS/BMS.hpp
+++ b/include/BMS/BMS.hpp
@@ -101,7 +101,6 @@ private:
     static constexpr EVT::core::IO::GPIO::State BMS_NOT_OK =
         EVT::core::IO::GPIO::State::LOW;
 
-
     /**
      * The interface for storaging and retrieving BQ Settings.
      */
@@ -148,7 +147,6 @@ private:
      * once per state change.
      */
     bool stateChanged = false;
-
 
     /**
      * Handles the start of the state machine logic. This considers the health

--- a/include/BMS/BMS.hpp
+++ b/include/BMS/BMS.hpp
@@ -136,7 +136,7 @@ private:
 
     /**
      * This GPIO is used to represent when the system is ok. When this pin
-     * is high, it is represents that the BMS is in a state ready to
+     * is high, it represents that the BMS is in a state ready to
      * charge or discharge,
      */
     EVT::core::IO::GPIO& bmsOK;

--- a/include/BMS/BMS.hpp
+++ b/include/BMS/BMS.hpp
@@ -46,7 +46,7 @@ public:
      */
     BMS(BQSettingsStorage& bqSettingsStorage, DEV::BQ76952 bq,
         DEV::Interlock& interlock, EVT::core::IO::GPIO& alarm,
-        DEV::SystemDetect& systemDetect);
+        DEV::SystemDetect& systemDetect, EVT::core::IO::GPIO& bmsOK);
 
     /**
      * The node ID used to identify the device on the CAN network.
@@ -90,6 +90,19 @@ private:
         EVT::core::IO::GPIO::State::HIGH;
 
     /**
+     * State for representing the BMS is in an OK state to charge/discharge
+     */
+    static constexpr EVT::core::IO::GPIO::State BMS_OK =
+        EVT::core::IO::GPIO::State::HIGH;
+
+    /**
+     * State for representing the BMS is in not in an OK state to charge/discharge
+     */
+    static constexpr EVT::core::IO::GPIO::State BMS_NOT_OK =
+        EVT::core::IO::GPIO::State::LOW;
+
+
+    /**
      * The interface for storaging and retrieving BQ Settings.
      */
     BQSettingsStorage& bqSettingsStorage;
@@ -121,6 +134,21 @@ private:
      * This determines which system the BMS is attached to.
      */
     DEV::SystemDetect& systemDetect;
+
+    /**
+     * This GPIO is used to represent when the system is ok. When this pin
+     * is high, it is represents that the BMS is in a state ready to
+     * charge or discharge,
+     */
+    EVT::core::IO::GPIO& bmsOK;
+
+    /**
+     * Boolean flag that represents a state has just changed, this is useful
+     * for determining when operations should take place that only take place
+     * once per state change.
+     */
+    bool stateChanged = false;
+
 
     /**
      * Handles the start of the state machine logic. This considers the health

--- a/src/BMS.cpp
+++ b/src/BMS.cpp
@@ -57,7 +57,7 @@ void BMS::process() {
 }
 
 void BMS::startState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
         stateChanged = false;
     }
@@ -83,14 +83,14 @@ void BMS::startState() {
 }
 
 void BMS::initializationErrorState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
         stateChanged = false;
     }
 }
 
 void BMS::factoryInitState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
         stateChanged = false;
     }
@@ -103,7 +103,7 @@ void BMS::factoryInitState() {
 }
 
 void BMS::transferSettingsState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
         stateChanged = false;
     }
@@ -124,7 +124,7 @@ void BMS::transferSettingsState() {
 }
 
 void BMS::systemReadyState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
         stateChanged = false;
     }
@@ -150,14 +150,14 @@ void BMS::systemReadyState() {
 }
 
 void BMS::unsafeConditionsError() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
         stateChanged = false;
     }
 }
 
 void BMS::powerDeliveryState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_OK);
         stateChanged = false;
     }
@@ -176,7 +176,7 @@ void BMS::powerDeliveryState() {
 }
 
 void BMS::chargingState() {
-    if(stateChanged) {
+    if (stateChanged) {
         bmsOK.writePin(BMS_OK);
         stateChanged = false;
     }

--- a/src/BMS.cpp
+++ b/src/BMS.cpp
@@ -5,13 +5,16 @@ namespace BMS {
 
 BMS::BMS(BQSettingsStorage& bqSettingsStorage, DEV::BQ76952 bq,
          DEV::Interlock& interlock, EVT::core::IO::GPIO& alarm,
-         DEV::SystemDetect& systemDetect) : bqSettingsStorage(bqSettingsStorage),
-                                            bq(bq),
-                                            interlock(interlock),
-                                            alarm(alarm),
-                                            systemDetect(systemDetect) {
+         DEV::SystemDetect& systemDetect, EVT::core::IO::GPIO& bmsOK) : bqSettingsStorage(bqSettingsStorage),
+                                                                        bq(bq),
+                                                                        interlock(interlock),
+                                                                        alarm(alarm),
+                                                                        systemDetect(systemDetect),
+                                                                        bmsOK(bmsOK) {
 
     state = State::START;
+    bmsOK.writePin(EVT::core::IO::GPIO::State::LOW);
+    stateChanged = false;
 }
 
 CO_OBJ_T* BMS::getObjectDictionary() {
@@ -54,34 +57,57 @@ void BMS::process() {
 }
 
 void BMS::startState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_NOT_OK);
+        stateChanged = false;
+    }
+
     // Check to see if communication is possible with the BQ chip
     // TODO: Try this n number of times before failing
     if (bq.communicationStatus() != DEV::BQ76952::Status::OK) {
         // If communication could not be handled, transition to error state
         // TODO: Update error mapping with error information
         state = State::INITIALIZATION_ERROR;
+        stateChanged = true;
     }
     // Check to see if we have setting to be transferred
     else if (bqSettingsStorage.hasSettings()) {
         state = State::TRANSFER_SETTINGS;
+        stateChanged = true;
     }
     // Otherwise, no current settings, wait until setting are received
     else {
         state = State::FACTORY_INIT;
+        stateChanged = true;
     }
 }
 
 void BMS::initializationErrorState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_NOT_OK);
+        stateChanged = false;
+    }
 }
 
 void BMS::factoryInitState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_NOT_OK);
+        stateChanged = false;
+    }
+
     // Check to see if settings have come in, if so, go back to start state
     if (bqSettingsStorage.hasSettings()) {
         state = State::START;
+        stateChanged = true;
     }
 }
 
 void BMS::transferSettingsState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_NOT_OK);
+        stateChanged = false;
+    }
+
     // TODO: Attempt n number of times before failing
     auto result = bqSettingsStorage.transferSettings();
     if (result != DEV::BQ76952::Status::OK) {
@@ -89,54 +115,82 @@ void BMS::transferSettingsState() {
         // error state
         // TODO: Update error mapping with error information
         state = State::INITIALIZATION_ERROR;
+        stateChanged = true;
     } else {
         // Otherwise, move on to ready state
         state = State::SYSTEM_READY;
+        stateChanged = true;
     }
 }
 
 void BMS::systemReadyState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_NOT_OK);
+        stateChanged = false;
+    }
+
     // TODO: Check for need to deep sleep and enter deep sleep mode
 
     // TODO: Update error register of BMS
     if (!isHealthy()) {
         state = State::UNSAFE_CONDITIONS_ERROR;
+        stateChanged = true;
         return;
     }
 
     if (interlock.isDetected()) {
         if (systemDetect.getIdentifiedSystem() == DEV::SystemDetect::System::BIKE) {
             state = State::POWER_DELIVERY;
+            stateChanged = true;
         } else if (systemDetect.getIdentifiedSystem() == DEV::SystemDetect::System::CHARGER) {
             state = State::CHARGING;
+            stateChanged = true;
         }
     }
 }
 
 void BMS::unsafeConditionsError() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_NOT_OK);
+        stateChanged = false;
+    }
 }
 
 void BMS::powerDeliveryState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_OK);
+        stateChanged = false;
+    }
+
     // TODO: Update error register of BMS
     if (!isHealthy()) {
         state = State::UNSAFE_CONDITIONS_ERROR;
+        stateChanged = true;
         return;
     }
 
     if (!interlock.isDetected()) {
         state = State::SYSTEM_READY;
+        stateChanged = true;
     }
 }
 
 void BMS::chargingState() {
+    if(stateChanged) {
+        bmsOK.writePin(BMS_OK);
+        stateChanged = false;
+    }
+
     // TODO: Update error register of BMS
     if (!isHealthy()) {
         state = State::UNSAFE_CONDITIONS_ERROR;
+        stateChanged = true;
         return;
     }
 
     if (!interlock.isDetected()) {
         state = State::SYSTEM_READY;
+        stateChanged = true;
     }
 }
 

--- a/targets/BMS/main.cpp
+++ b/targets/BMS/main.cpp
@@ -136,7 +136,7 @@ int main() {
 
     // Initialize the system OK pin
     // TODO: Determine actual system ok pin
-    IO::GPIO& bmsOK = IO::getGPIO<IO::Pin::PC_14>(IO::GPIO::Direction::OUTPUT);
+    IO::GPIO& bmsOK = IO::getGPIO<IO::Pin::PB_3>(IO::GPIO::Direction::OUTPUT);
 
     // Intialize the BMS itself
     BMS::BMS bms(bqSettingsStorage, bq, interlock, alarm, systemDetect, bmsOK);

--- a/targets/BMS/main.cpp
+++ b/targets/BMS/main.cpp
@@ -134,8 +134,12 @@ int main() {
     // Intialize the alarm pin
     IO::GPIO& alarm = IO::getGPIO<IO::Pin::PB_1>(IO::GPIO::Direction::INPUT);
 
+    // Initialize the system OK pin
+    // TODO: Determine actual system ok pin
+    IO::GPIO& bmsOK = IO::getGPIO<IO::Pin::PC_14>(IO::GPIO::Direction::OUTPUT);
+
     // Intialize the BMS itself
-    BMS::BMS bms(bqSettingsStorage, bq, interlock, alarm, systemDetect);
+    BMS::BMS bms(bqSettingsStorage, bq, interlock, alarm, systemDetect, bmsOK);
 
     // Reserved memory for CANopen stack usage
     uint8_t sdoBuffer[1][CO_SDO_BUF_BYTE];

--- a/targets/system_detect/main.cpp
+++ b/targets/system_detect/main.cpp
@@ -105,8 +105,13 @@ int main() {
     // Intialize the alarm pin
     IO::GPIO& alarm = IO::getGPIO<IO::Pin::PB_1>(IO::GPIO::Direction::INPUT);
 
+    // Initialize the system OK pin
+    // TODO: Determine actual system ok pin
+    IO::GPIO& bmsOK = IO::getGPIO<IO::Pin::PC_14>(IO::GPIO::Direction::OUTPUT);
+
+
     // Intialize the BMS itself
-    BMS::BMS bms(bqSettingsStorage, bq, interlock, alarm, systemDetect);
+    BMS::BMS bms(bqSettingsStorage, bq, interlock, alarm, systemDetect, bmsOK);
 
     // Reserved memory for CANopen stack usage
     uint8_t sdoBuffer[1][CO_SDO_BUF_BYTE];

--- a/targets/system_detect/main.cpp
+++ b/targets/system_detect/main.cpp
@@ -109,7 +109,6 @@ int main() {
     // TODO: Determine actual system ok pin
     IO::GPIO& bmsOK = IO::getGPIO<IO::Pin::PC_14>(IO::GPIO::Direction::OUTPUT);
 
-
     // Intialize the BMS itself
     BMS::BMS bms(bqSettingsStorage, bq, interlock, alarm, systemDetect, bmsOK);
 


### PR DESCRIPTION
Add GPIO signal for representing when the BMS is in a state to charge/discharge. This fits into the state diagram such that, when the system is in "Charging" or "Power Delivery" the `bmsOK` GPIO is HIGH, LOW everywhere else.

Also adds a flag to represent when a state change has taken place for operations that need to only take place once per state (like changing the GPIO)