### PR TITLE
Sharing CPU Resources is Caring

### DIFF
--- a/include/BMS/BQSettingStorage.hpp
+++ b/include/BMS/BQSettingStorage.hpp
@@ -93,10 +93,34 @@ public:
     EVT::core::DEV::M24C32& getEEPROM();
 
     /**
-     * Transfer settings from EEPROM to the BQ chip. This will read the
-     * settings one-by-one and pass the setting to the BQ chip for programming.
+     * Reset the transfer setting logic. This will mean that the next call
+     * to BQSettingsStorage::transferSetting will tranfer the first stored
+     * setting.
      */
-    BMS::DEV::BQ76952::Status transferSettings();
+    void resetTranfer();
+
+    /**
+     * Transfer a single setting over to the BQ chip. Will update the given
+     * flag to represent that the setting that was tranferred by the most
+     * recent call represented the last setting that needed to be transferred.
+     *
+     * For example, if there are 3 settings, the flow of the code would be
+     * as follows.
+     *
+     * NOTE: BQSettingsStorage::resetTransfer must be called before the
+     * first call to transferSetting
+     *
+     * \code{.cpp}
+     * bool isComplete;
+     * resetTransfer();
+     * transferSetting(&isComplete); // isComplete -> false
+     * transferSetting(&isComplete); // isComplete -> false
+     * transferSetting(&isComplete); // isComplete -> true
+     * \endcode
+     *
+     * @param[out] isComplete Flag that represents all settings have been transferred
+     */
+    BMS::DEV::BQ76952::Status transferSetting(bool& isComplete);
 
     /**
      * Checks to see if the settings are stored and can be used. This includes
@@ -136,6 +160,11 @@ private:
      * written over yet.
      */
     uint16_t numSettingsWritten;
+    /**
+     * The number of settings that have been transferred from the BMS to the
+     * BQ
+     */
+    uint16_t numSettingsTransferred;
 
     friend class BMS;
 };

--- a/src/BMS.cpp
+++ b/src/BMS.cpp
@@ -105,19 +105,21 @@ void BMS::factoryInitState() {
 void BMS::transferSettingsState() {
     if (stateChanged) {
         bmsOK.writePin(BMS_NOT_OK);
+        bqSettingsStorage.resetTranfer();
         stateChanged = false;
     }
 
     // TODO: Attempt n number of times before failing
-    auto result = bqSettingsStorage.transferSettings();
+    bool isComplete = false;
+    auto result = bqSettingsStorage.transferSetting(isComplete);
     if (result != DEV::BQ76952::Status::OK) {
         // If the settings did not transfer successfully, transiton tp
         // error state
         // TODO: Update error mapping with error information
         state = State::INITIALIZATION_ERROR;
         stateChanged = true;
-    } else {
-        // Otherwise, move on to ready state
+    } else if (isComplete) {
+        // Otherwise, move on to ready state if all settings have been transferred
         state = State::SYSTEM_READY;
         stateChanged = true;
     }

--- a/src/BQSettingStorage.cpp
+++ b/src/BQSettingStorage.cpp
@@ -246,7 +246,7 @@ BMS::DEV::BQ76952::Status BQSettingsStorage::transferSetting(bool& isComplete) {
 
         LOGGER.log(BMSLogger::LogLevel::ERROR,
                    "Failed with address: 0x%04x, data: 0x%04x",
-                    setting.getAddress(), setting.getData());
+                   setting.getAddress(), setting.getData());
 
         bq.exitConfigUpdateMode();
         return status;

--- a/targets/settings_transfer/main.cpp
+++ b/targets/settings_transfer/main.cpp
@@ -33,7 +33,7 @@ int main() {
     bool isComplete = false;
     settingsStorage.resetTranfer();
     uint16_t count = 0;
-    while(!isComplete) {
+    while (!isComplete) {
         auto status = settingsStorage.transferSetting(isComplete);
 
         switch (status) {

--- a/targets/settings_transfer/main.cpp
+++ b/targets/settings_transfer/main.cpp
@@ -30,24 +30,29 @@ int main() {
     BMS::DEV::BQ76952 bq(i2c, BQ_I2C_ADDR);
     BMS::BQSettingsStorage settingsStorage(eeprom, bq);
 
-    auto status = settingsStorage.transferSettings();
+    bool isComplete = false;
+    settingsStorage.resetTranfer();
+    uint16_t count = 0;
+    while(!isComplete) {
+        auto status = settingsStorage.transferSetting(isComplete);
 
-    switch (status) {
-    case BMS::DEV::BQ76952::Status::ERROR:
-        uart.printf("FAILED: BQ specific error\r\n");
-        break;
-    case BMS::DEV::BQ76952::Status::I2C_ERROR:
-        uart.printf("FAILED: I2C error\r\n");
-        break;
-    case BMS::DEV::BQ76952::Status::TIMEOUT:
-        uart.printf("FAILED: Timeout waiting for BQ\r\n");
-        break;
-    case BMS::DEV::BQ76952::Status::OK:
-        uart.printf("SUCCESS\r\n");
-        break;
-    default:
-        uart.printf("FAILED: Unknown error\r\n");
-        break;
+        switch (status) {
+        case BMS::DEV::BQ76952::Status::ERROR:
+            uart.printf("FAILED: BQ specific error\r\n");
+            break;
+        case BMS::DEV::BQ76952::Status::I2C_ERROR:
+            uart.printf("FAILED: I2C error\r\n");
+            break;
+        case BMS::DEV::BQ76952::Status::TIMEOUT:
+            uart.printf("FAILED: Timeout waiting for BQ\r\n");
+            break;
+        case BMS::DEV::BQ76952::Status::OK:
+            uart.printf("SUCCESS\r\n");
+            break;
+        default:
+            uart.printf("FAILED: Unknown error\r\n");
+            break;
+        }
     }
 
     EVT::core::time::wait(500);

--- a/targets/settings_transfer/main.cpp
+++ b/targets/settings_transfer/main.cpp
@@ -32,7 +32,6 @@ int main() {
 
     bool isComplete = false;
     settingsStorage.resetTranfer();
-    uint16_t count = 0;
     while (!isComplete) {
         auto status = settingsStorage.transferSetting(isComplete);
 


### PR DESCRIPTION
Refactor the logic for transferring settings to the BQ so that settings are transferred one at a time rather than all at once. This means that the system can still respond to CANopen messages, pet a watchdog, etc since the system is not hung up transferring all of the settings.