### PR TITLE
Here have this PR for these Trying times

### DIFF
--- a/include/BMS/BMS.hpp
+++ b/include/BMS/BMS.hpp
@@ -102,6 +102,17 @@ private:
         EVT::core::IO::GPIO::State::LOW;
 
     /**
+     * Number of attempts that will be made to communicate with the BQ
+     * before failing
+     */
+    static constexpr uint16_t MAX_BQ_COMM_ATTEMPTS = 3;
+
+    /**
+     * Time in milliseconds between attempting a previously failed operation
+     */
+    static constexpr uint32_t ERROR_TIME_DELAY = 2000;
+
+    /**
      * The interface for storaging and retrieving BQ Settings.
      */
     BQSettingsStorage& bqSettingsStorage;
@@ -147,6 +158,23 @@ private:
      * once per state change.
      */
     bool stateChanged = false;
+
+    /**
+     * Utility variable which can be used to count the number of attempts that
+     * was made to complete a certain actions.
+     *
+     * For example, this is used for trying to communicate with the BQ N
+     * number of times before failing
+     */
+    uint16_t numAttemptsMade;
+
+    /**
+     * Keeps track of the last time an attempt was made. This is used in
+     * combination with BMS::numAttemptsMade to attempt a task a certain
+     * number of times with delay in attempts
+     */
+    uint32_t lastAttemptTime;
+
 
     /**
      * Handles the start of the state machine logic. This considers the health

--- a/include/BMS/BMS.hpp
+++ b/include/BMS/BMS.hpp
@@ -175,7 +175,6 @@ private:
      */
     uint32_t lastAttemptTime;
 
-
     /**
      * Handles the start of the state machine logic. This considers the health
      * of the system, and the existance of BQ settings.

--- a/include/BMS/BMS.hpp
+++ b/include/BMS/BMS.hpp
@@ -110,7 +110,7 @@ private:
     /**
      * Time in milliseconds between attempting a previously failed operation
      */
-    static constexpr uint32_t ERROR_TIME_DELAY = 2000;
+    static constexpr uint32_t ERROR_TIME_DELAY = 5000;
 
     /**
      * The interface for storaging and retrieving BQ Settings.

--- a/src/BMS.cpp
+++ b/src/BMS.cpp
@@ -17,7 +17,7 @@ BMS::BMS(BQSettingsStorage& bqSettingsStorage, DEV::BQ76952 bq,
 
     state = State::START;
     bmsOK.writePin(EVT::core::IO::GPIO::State::LOW);
-    stateChanged = false;
+    stateChanged = true;
 }
 
 CO_OBJ_T* BMS::getObjectDictionary() {

--- a/src/BQSettingStorage.cpp
+++ b/src/BQSettingStorage.cpp
@@ -224,7 +224,6 @@ void BQSettingsStorage::resetEEPROMOffset() {
 void BQSettingsStorage::resetTranfer() {
     numSettingsTransferred = 0;
     resetEEPROMOffset();
-    bq.enterConfigUpdateMode();
 }
 
 BMS::DEV::BQ76952::Status BQSettingsStorage::transferSetting(bool& isComplete) {
@@ -232,6 +231,10 @@ BMS::DEV::BQ76952::Status BQSettingsStorage::transferSetting(bool& isComplete) {
     if (numSettingsTransferred == numSettings) {
         isComplete = true;
         return BMS::DEV::BQ76952::Status::OK;
+    }
+
+    if (numSettingsTransferred == 0) {
+        bq.enterConfigUpdateMode();
     }
 
     // Otherwise transfer a single setting


### PR DESCRIPTION
Adds wrapper around communication with the BQ to try multiple times before entering an error state. What takes place during an error is that the system will

1. Record the number of times this error has taken place
2. If the number of times is above the threshold, enter the error state
3. Otherwise keep track of the time the error took place and try again in N number of milliseconds.